### PR TITLE
Add subscription error codes to mid groups (RV develop)

### DIFF
--- a/src/sessionControlClient.js
+++ b/src/sessionControlClient.js
@@ -688,6 +688,13 @@ class SessionControlClient extends EventEmitter {
             return;
         }
 
+        if (midGroupList[midGroup].subscribe === undefined) {
+            let err = new Error(`[Session Control Client] [Subscribe] subscribing to midGroup [${midGroup}] is not supported`);
+            debug("SessionControlClient _subscribe err_unsupported_midGroup");
+            cb(err);
+            return;
+        }
+
         let mid = opts || {};
 
         let type = SUBSCRIBE;
@@ -744,6 +751,13 @@ class SessionControlClient extends EventEmitter {
         if (midGroupList[midGroup] === undefined) {
             let err = new Error(`[Session Control Client] [Unsubscribe] invalid groupMid [${midGroup}]`);
             debug("SessionControlClient _unsubscribe err_invalid_midGroup");
+            cb(err);
+            return;
+        }
+
+        if (midGroupList[midGroup].unsubscribe === undefined) {
+            let err = new Error(`[Session Control Client] [Unsubscribe] unsubscribing from midGroup [${midGroup}] is not supported`);
+            debug("SessionControlClient _unsubscribe err_unsupported_midGroup");
             cb(err);
             return;
         }


### PR DESCRIPTION
src/constants.js defines a mapping between error codes and a text message for what they represent.

Almost every subscription has at least two error codes, one for when the subscription already exists, and the other for when attempting to unsubscribe from a non-existent subscription.

This PR adds these error codes in the midGroups list, so it's possible for other libraries to know which mid group an error code corresponds to.

Additionally, error handling is added to prevent un/subscribing to mids that do not support that.