### PR TITLE
Fix LinkLayer _destroy

### DIFF
--- a/src/linkLayer.js
+++ b/src/linkLayer.js
@@ -362,7 +362,7 @@ class LinkLayer extends Duplex {
         }
     }
 
-    _destroy() {
+    _destroy(err, callback) {
         debug("LinkLayer _destroy");
 
         clearTimeout(this.timer);
@@ -380,6 +380,8 @@ class LinkLayer extends Duplex {
         destroyStream(this.opSerializer);
         destroyStream(this.midParser);
         destroyStream(this.midSerializer);
+
+        callback(err);
     }
 
     finishCycle(err) {

--- a/src/linkLayer.js
+++ b/src/linkLayer.js
@@ -121,11 +121,8 @@ class LinkLayer extends Duplex {
         }
 
         if (this.callbackWrite) {
-            function doCallback(cb) {
-                process.nextTick(() => cb());
-            }
-
-            doCallback(this.callbackWrite);
+            const cb = this.callbackWrite;
+            process.nextTick(() => cb());
 
             this.callbackWrite = undefined;
         }
@@ -429,12 +426,8 @@ class LinkLayer extends Duplex {
                 ` Expect MID[${this.message.mid}] - Expect SequenceNumber [${this.sequenceNumber}] - Current SequenceNumber [${data.sequenceNumber}]`);
 
             if (this.callbackWrite) {
-
-                function doCallback(cb, err) {
-                    process.nextTick(() => cb(err));
-                }
-
-                doCallback(this.callbackWrite, err);
+                const cb = this.callbackWrite;
+                process.nextTick(() => cb(err));
 
                 this.callbackWrite = undefined;
 
@@ -449,12 +442,8 @@ class LinkLayer extends Duplex {
         this.message = {};
 
         if (this.callbackWrite) {
-
-            function doCallback(cb) {
-                process.nextTick(() => cb());
-            }
-
-            doCallback(this.callbackWrite);
+            const callbackWrite = this.callbackWrite;
+            process.nextTick(() => callbackWrite());
 
             this.callbackWrite = undefined;
         }
@@ -502,15 +491,10 @@ class LinkLayer extends Duplex {
             this.resentTimes = 0;
 
             if (this.callbackWrite) {
-
-                function doCallback(cb, err) {
-                    process.nextTick(() => cb(err));
-                }
-
-                doCallback(this.callbackWrite, err);
+                const cb = this.callbackWrite;
+                process.nextTick(() => cb(err));
 
                 this.callbackWrite = undefined;
-
             } else {
                 debug('LinkLayer _resendMid  err-timeout_send_MID', this.message.mid);
                 this.emit("error", err);


### PR DESCRIPTION
calling the callback passed to _destroy is not explicity mentioned as required in the nodejs docs, but it's necessary for error propagation.

this is why the tests listening for an error event from link layer would fail, because even though the link layer would be destroyed, it would not emit an error event.

closes https://github.com/st-one-io/node-open-protocol/issues/43